### PR TITLE
add network interface support to node collector

### DIFF
--- a/collectors/node/node.go
+++ b/collectors/node/node.go
@@ -6,10 +6,12 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"emperror.dev/errors"
 	"github.com/shirou/gopsutil/v3/host"
+	"github.com/shirou/gopsutil/v3/net"
 
 	"github.com/gezacorp/metadatax"
 )
@@ -19,18 +21,28 @@ const (
 )
 
 type collector struct {
-	getHostMetadataFunc GetHostMetadataFunc
+	getHostMetadataFunc      GetHostMetadataFunc
+	getNetworkInterfacesFunc GetNetworkInterfacesFunc
 
 	mdContainerInitFunc func() metadatax.MetadataContainer
 }
 
 type CollectorOption func(*collector)
 
-type GetHostMetadataFunc func(context.Context) (*host.InfoStat, error)
+type (
+	GetHostMetadataFunc      func(context.Context) (*host.InfoStat, error)
+	GetNetworkInterfacesFunc func(context.Context) (net.InterfaceStatList, error)
+)
 
 func CollectorWithGetHostMetadataFunc(fn GetHostMetadataFunc) CollectorOption {
 	return func(c *collector) {
 		c.getHostMetadataFunc = fn
+	}
+}
+
+func CollectorWithGetNetworkInterfacesFunc(fn GetNetworkInterfacesFunc) CollectorOption {
+	return func(c *collector) {
+		c.getNetworkInterfacesFunc = fn
 	}
 }
 
@@ -41,14 +53,13 @@ func CollectorWithMetadataContainerInitFunc(fn func() metadatax.MetadataContaine
 }
 
 func New(opts ...CollectorOption) metadatax.Collector {
-	c := &collector{}
+	c := &collector{
+		getHostMetadataFunc:      getHostMetadata,
+		getNetworkInterfacesFunc: getNetworkInterfaces,
+	}
 
 	for _, f := range opts {
 		f(c)
-	}
-
-	if c.getHostMetadataFunc == nil {
-		c.getHostMetadataFunc = getHostMetadata
 	}
 
 	if c.mdContainerInitFunc == nil {
@@ -89,7 +100,29 @@ func (c *collector) GetMetadata(ctx context.Context) (metadatax.MetadataContaine
 	kernel.AddLabel("version", info.KernelVersion)
 	kernel.AddLabel("arch", info.KernelArch)
 
+	ifaces, err := c.getNetworkInterfacesFunc(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ifacesMd := md.Segment("network").Segment("interface")
+	ifacesMd.AddLabel("count", strconv.Itoa(len(ifaces)))
+	for _, iface := range ifaces {
+		ifacesMd.AddLabel("name", iface.Name)
+		ifaceMd := ifacesMd.Segment(iface.Name).
+			AddLabel("mac_address", iface.HardwareAddr).
+			AddLabel("mtu", strconv.Itoa(iface.MTU))
+
+		for _, addr := range iface.Addrs {
+			ifaceMd.AddLabel("ip", addr.Addr)
+		}
+	}
+
 	return md, nil
+}
+
+func getNetworkInterfaces(ctx context.Context) (net.InterfaceStatList, error) {
+	return net.InterfacesWithContext(ctx)
 }
 
 func getHostMetadata(ctx context.Context) (*host.InfoStat, error) {

--- a/collectors/node/node.go
+++ b/collectors/node/node.go
@@ -114,7 +114,13 @@ func (c *collector) GetMetadata(ctx context.Context) (metadatax.MetadataContaine
 			AddLabel("mtu", strconv.Itoa(iface.MTU)).
 			AddLabel("index", strconv.Itoa(iface.Index))
 
-		for _, addr := range iface.Addrs {
+		for i, addr := range iface.Addrs {
+			t := "public"
+			if IsInternalIP(addr.Addr) {
+				t = "private"
+			}
+
+			ifaceMd.Segment("ip").Segment(strconv.Itoa(i)).AddLabel("address", addr.Addr).AddLabel("type", t)
 			ifaceMd.AddLabel("ip", addr.Addr)
 		}
 	}

--- a/collectors/node/node.go
+++ b/collectors/node/node.go
@@ -111,7 +111,8 @@ func (c *collector) GetMetadata(ctx context.Context) (metadatax.MetadataContaine
 		ifacesMd.AddLabel("name", iface.Name)
 		ifaceMd := ifacesMd.Segment(iface.Name).
 			AddLabel("mac_address", iface.HardwareAddr).
-			AddLabel("mtu", strconv.Itoa(iface.MTU))
+			AddLabel("mtu", strconv.Itoa(iface.MTU)).
+			AddLabel("index", strconv.Itoa(iface.Index))
 
 		for _, addr := range iface.Addrs {
 			ifaceMd.AddLabel("ip", addr.Addr)

--- a/collectors/node/node_test.go
+++ b/collectors/node/node_test.go
@@ -33,6 +33,7 @@ func TestGetMetadata(t *testing.T) {
 		"node:network:interface:lo0:mac_address": {"3a:f3:9f:a1:81:d0"},
 		"node:network:interface:lo0:mtu":         {"1500"},
 		"node:network:interface:name":            {"lo0"},
+		"node:network:interface:lo0:index":       {"0"},
 	}
 
 	collector := node.New(

--- a/collectors/node/node_test.go
+++ b/collectors/node/node_test.go
@@ -28,12 +28,16 @@ func TestGetMetadata(t *testing.T) {
 		"node:virtualization:type": {"xen"},
 		"node:virtualization:role": {"guest"},
 
-		"node:network:interface:count":           {"1"},
-		"node:network:interface:lo0:ip":          {"127.0.0.1/8", "::1/128"},
-		"node:network:interface:lo0:mac_address": {"3a:f3:9f:a1:81:d0"},
-		"node:network:interface:lo0:mtu":         {"1500"},
-		"node:network:interface:name":            {"lo0"},
-		"node:network:interface:lo0:index":       {"0"},
+		"node:network:interface:count":            {"1"},
+		"node:network:interface:lo0:ip":           {"127.0.0.1/8", "::1/128"},
+		"node:network:interface:lo0:ip:0:address": {"127.0.0.1/8"},
+		"node:network:interface:lo0:ip:0:type":    {"private"},
+		"node:network:interface:lo0:ip:1:address": {"::1/128"},
+		"node:network:interface:lo0:ip:1:type":    {"private"},
+		"node:network:interface:lo0:mac_address":  {"3a:f3:9f:a1:81:d0"},
+		"node:network:interface:lo0:mtu":          {"1500"},
+		"node:network:interface:name":             {"lo0"},
+		"node:network:interface:lo0:index":        {"0"},
 	}
 
 	collector := node.New(

--- a/collectors/node/node_test.go
+++ b/collectors/node/node_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/shirou/gopsutil/v3/host"
+	"github.com/shirou/gopsutil/v3/net"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/gezacorp/metadatax"
@@ -26,6 +27,12 @@ func TestGetMetadata(t *testing.T) {
 		"node:uuid":                {"9c4f3853-4193-4700-ae6e-f23c61fd120c"},
 		"node:virtualization:type": {"xen"},
 		"node:virtualization:role": {"guest"},
+
+		"node:network:interface:count":           {"1"},
+		"node:network:interface:lo0:ip":          {"127.0.0.1/8", "::1/128"},
+		"node:network:interface:lo0:mac_address": {"3a:f3:9f:a1:81:d0"},
+		"node:network:interface:lo0:mtu":         {"1500"},
+		"node:network:interface:name":            {"lo0"},
 	}
 
 	collector := node.New(
@@ -41,6 +48,24 @@ func TestGetMetadata(t *testing.T) {
 				KernelArch:           "aarch64",
 				VirtualizationSystem: "xen",
 				VirtualizationRole:   "guest",
+			}, nil
+		}),
+		node.CollectorWithGetNetworkInterfacesFunc(func(context.Context) (net.InterfaceStatList, error) {
+			return []net.InterfaceStat{
+				{
+					Index:        0,
+					MTU:          1500,
+					Name:         "lo0",
+					HardwareAddr: "3a:f3:9f:a1:81:d0",
+					Addrs: []net.InterfaceAddr{
+						{
+							Addr: "127.0.0.1/8",
+						},
+						{
+							Addr: "::1/128",
+						},
+					},
+				},
 			}, nil
 		}),
 		node.CollectorWithMetadataContainerInitFunc(func() metadatax.MetadataContainer {

--- a/collectors/node/util.go
+++ b/collectors/node/util.go
@@ -1,0 +1,67 @@
+package node
+
+import (
+	"net"
+	"strings"
+)
+
+// internalNetworks lists non-routable IPv4/IPv6 ranges.
+var internalNetworks []*net.IPNet
+
+func init() {
+	cidrs := []string{
+		// IPv4 private
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+
+		// IPv4 special-use
+		"127.0.0.0/8",        // loopback
+		"169.254.0.0/16",     // link-local
+		"100.64.0.0/10",      // carrier-grade NAT
+		"198.18.0.0/15",      // benchmarking
+		"0.0.0.0/8",          // unspecified
+		"255.255.255.255/32", // broadcast
+
+		// IPv6 special-use
+		"fc00::/7",  // unique local
+		"fe80::/10", // link-local
+		"::1/128",   // loopback
+		"::/128",    // unspecified
+	}
+
+	for _, cidr := range cidrs {
+		_, n, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(err)
+		}
+		internalNetworks = append(internalNetworks, n)
+	}
+}
+
+// IsInternalIP returns true if the IP is from a non-routable/internal range.
+func IsInternalIP(ip string) bool {
+	var nip net.IP
+	var err error
+
+	if strings.Contains(ip, "/") {
+		nip, _, err = net.ParseCIDR(ip)
+		if err != nil {
+			return false
+		}
+	} else {
+		nip = net.ParseIP(ip)
+	}
+
+	if nip == nil {
+		return false
+	}
+
+	for _, n := range internalNetworks {
+		if n.Contains(nip) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/metadata.go
+++ b/metadata.go
@@ -140,8 +140,9 @@ func (m *metadata) Segment(name string, opts ...MetadataOption) MetadataContaine
 		WithPrefix(name),
 		WithMetadata(m),
 	}
+
 	if m.mu == nil {
-		opts = append(opts, WithoutConcurrencySupport())
+		inheritedOpts = append(inheritedOpts, WithoutConcurrencySupport())
 	}
 
 	return New(append(inheritedOpts, opts...)...)
@@ -227,7 +228,7 @@ func (m *metadata) AddLabel(name string, values ...string) MetadataContainer {
 	defer m.unlock()
 
 	if !m.opts.allowEmptyValues {
-		if values == nil {
+		if len(values) == 0 {
 			return m
 		}
 		_values := values[:0]
@@ -245,7 +246,7 @@ func (m *metadata) AddLabel(name string, values ...string) MetadataContainer {
 
 	if m.opts.prefix != "" {
 		if name != "" {
-			name = strings.Join([]string{m.opts.prefix, m.opts.segmentSeparator, name}, "")
+			name = m.opts.prefix + m.opts.segmentSeparator + name
 		} else {
 			name = m.opts.prefix
 		}


### PR DESCRIPTION
This change extends the node collector to also report network interface metadata.

Key updates:
- Collect network interfaces via gopsutil and emit metadata under `node:network:interface:*` (count, interface names, per-interface MAC, MTU, and IP addresses).
- Add an injectable `GetNetworkInterfacesFunc` (with a default implementation) to keep the collector testable and consistent with the host metadata injection pattern.
- Update the node collector unit test to cover the new network interface labels.
- Fix a couple of small metadata container issues:
  - Ensure `Segment()` correctly inherits `WithoutConcurrencySupport()` when the parent has no mutex.
  - Treat “no values provided” as `len(values) == 0` (instead of `values == nil`) when empty values are disallowed.
  - Simplify label prefix concatenation to avoid an unnecessary `strings.Join`.

Example collected interfaces metadata:

```
node:network:interface:count=4
node:network:interface:docker0:index=4
node:network:interface:docker0:ip=172.17.0.1/16
node:network:interface:docker0:ip:0:address=172.17.0.1/16
node:network:interface:docker0:ip:0:type=private
node:network:interface:docker0:mac_address=02:42:02:d7:71:85
node:network:interface:docker0:mtu=1500
node:network:interface:eth0:index=2
node:network:interface:eth0:ip=192.168.5.15/24
node:network:interface:eth0:ip=fe80::5055:55ff:fea8:2c49/64
node:network:interface:eth0:ip:0:address=192.168.5.15/24
node:network:interface:eth0:ip:0:type=private
node:network:interface:eth0:ip:1:address=fe80::5055:55ff:fea8:2c49/64
node:network:interface:eth0:ip:1:type=private
node:network:interface:eth0:mac_address=52:55:55:a8:2c:49
node:network:interface:eth0:mtu=1500
node:network:interface:lima0:index=3
node:network:interface:lima0:ip=192.168.105.3/24
node:network:interface:lima0:ip=fd91:3e4c:10db:b813:5055:55ff:feda:64fb/64
node:network:interface:lima0:ip=fe80::5055:55ff:feda:64fb/64
node:network:interface:lima0:ip:0:address=192.168.105.3/24
node:network:interface:lima0:ip:0:type=private
node:network:interface:lima0:ip:1:address=fd91:3e4c:10db:b813:5055:55ff:feda:64fb/64
node:network:interface:lima0:ip:1:type=private
node:network:interface:lima0:ip:2:address=fe80::5055:55ff:feda:64fb/64
node:network:interface:lima0:ip:2:type=private
node:network:interface:lima0:mac_address=52:55:55:da:64:fb
node:network:interface:lima0:mtu=1500
node:network:interface:lo:index=1
node:network:interface:lo:ip=127.0.0.1/8
node:network:interface:lo:ip=::1/128
node:network:interface:lo:ip:0:address=127.0.0.1/8
node:network:interface:lo:ip:0:type=private
node:network:interface:lo:ip:1:address=::1/128
node:network:interface:lo:ip:1:type=private
node:network:interface:lo:mtu=65536
node:network:interface:name=lo
node:network:interface:name=eth0
node:network:interface:name=lima0
node:network:interface:name=docker0


